### PR TITLE
Simplified Marker Components for TwoStickShooter Pure

### DIFF
--- a/TwoStickShooter/Pure/Assets/GameCode/ComponentTypes.cs
+++ b/TwoStickShooter/Pure/Assets/GameCode/ComponentTypes.cs
@@ -39,10 +39,9 @@ namespace TwoStickPureExample
         public float Value;
     }
 
-    // Pure marker types
+    // Pure marker types.
     public struct Enemy : IComponentData { }
-    public struct EnemyShot : IComponentData { }
-    public struct PlayerShot : IComponentData { }
+    public struct Player : IComponentData { }
 
     public struct EnemyShootState : IComponentData
     {

--- a/TwoStickShooter/Pure/Assets/GameCode/ShotDamageSystem.cs
+++ b/TwoStickShooter/Pure/Assets/GameCode/ShotDamageSystem.cs
@@ -42,7 +42,7 @@ namespace TwoStickPureExample
             public int Length;
             public ComponentDataArray<Shot> Shot;
             [ReadOnly] public ComponentDataArray<Position2D> Position;
-            [ReadOnly] public ComponentDataArray<PlayerShot> PlayerShotMarker;
+            [ReadOnly] public ComponentDataArray<Player> PlayerMarker;
         }
         [Inject] PlayerShotData m_PlayerShots;
 
@@ -54,7 +54,7 @@ namespace TwoStickPureExample
             public int Length;
             public ComponentDataArray<Shot> Shot;
             [ReadOnly] public ComponentDataArray<Position2D> Position;
-            [ReadOnly] public ComponentDataArray<EnemyShot> EnemyShotMarker;
+            [ReadOnly] public ComponentDataArray<Enemy> EnemyMarker;
         }
         [Inject] EnemyShotData m_EnemyShots;
 

--- a/TwoStickShooter/Pure/Assets/GameCode/ShotSpawnSystem.cs
+++ b/TwoStickShooter/Pure/Assets/GameCode/ShotSpawnSystem.cs
@@ -35,13 +35,13 @@ namespace TwoStickPureExample
                 em.AddComponent(shotEntity, default(TransformMatrix));
                 if (sd.Faction == Factions.kPlayer)
                 {
-                    em.AddComponent(shotEntity, new PlayerShot());
+                    em.AddComponent(shotEntity, new Player()); // Mark as player shot.
                     em.AddComponent(shotEntity, new MoveSpeed {speed = TwoStickBootstrap.Settings.bulletMoveSpeed});
                     em.AddSharedComponent(shotEntity, TwoStickBootstrap.PlayerShotLook);
                 }
                 else
                 {
-                    em.AddComponent(shotEntity, new EnemyShot());
+                    em.AddComponent(shotEntity, new Enemy()); // Mark as enemy shot.
                     em.AddComponent(shotEntity, new MoveSpeed {speed = TwoStickBootstrap.Settings.enemyShotSpeed});
                     em.AddSharedComponent(shotEntity, TwoStickBootstrap.EnemyShotLook);
                 }


### PR DESCRIPTION
Having an `Enemy` and `EnemyShot` marker component is redundant and the suffix "Shot" makes these components less generic than they should be. So I removed `EnemyShot` completely and renamed `PlayerShot` to just `Player`.

I guess for a simple example project explicit naming makes things clearer, but it really seems to go against best practices and make things needlessly more complex.