### PR TITLE
Fixed use right job in performance test

### DIFF
--- a/Samples/Assets/PerformanceTests/Entities/NativeArrayIterationPerformanceTests.cs
+++ b/Samples/Assets/PerformanceTests/Entities/NativeArrayIterationPerformanceTests.cs
@@ -102,7 +102,7 @@ namespace Unity.Entities.PerformanceTests
                 Source = source,
                 ResetThreshold = resetThreshold
             };
-            var resetJobHandle = addDeltaJob.Schedule(source.Length, batchSize, addDeltaJobHandle);
+            var resetJobHandle = resetJob.Schedule(source.Length, batchSize, addDeltaJobHandle);
             resetJobHandle.Complete();
         }
 


### PR DESCRIPTION
addDeltaJob invoked second time, resetJob is never called