### PR TITLE
Update OccupantIncreaseSystem.cs

### DIFF
--- a/Samples/Assets/GalacticConquest/Scripts/Systems/OccupantIncreaseSystem.cs
+++ b/Samples/Assets/GalacticConquest/Scripts/Systems/OccupantIncreaseSystem.cs
@@ -52,8 +52,9 @@ namespace Systems
             spawnCounter += deltaTime;
             if (spawnCounter < spawnInterval)
                 return inputDeps;
-            spawnCounter = 0.0f;
-
+            //spawnCounter = 0.0f; 
+              spawnCounter -= spawnInterval; 
+              
             var job = new PlanetsOccupantsJob
             {
                 Data = planets.Data,


### PR DESCRIPTION
Setting spawnCounter to zero will result in loss of time. Not important in most cases, but IMHO best practice is to always subtract the interval.