### PR TITLE
Fixed `archetype` vs `chunk` confusion in `Documentation/reference/chunk_iteration.md` 

### DIFF
--- a/Documentation/reference/chunk_iteration.md
+++ b/Documentation/reference/chunk_iteration.md
@@ -216,7 +216,7 @@ var chunkEntities = chunk.GetNativeSlice(entityType);
 
 ## Accessing SharedComponent (index) data in chunks
 
-You cannot directly access `SharedComponent` in a `Chunk` because `SharedComponent` data is not stored in the `Chunks`. However, each `archetype` contains the index of the specific value of the `SharedComponent` which is part of its definition, and indexes into the global list of `SharedComponent` values.
+You cannot directly access `SharedComponent` in a `Chunk` because `SharedComponent` data is not stored in the `Chunks`. However, each `Chunk` contains the index of the specific value of the `SharedComponent` which is part of its definition, and indexes into the global list of `SharedComponent` values.
 
 Retrieving the `SharedComponent` index works very much like retrieving component data. An `ArchetypeChunkSharedComponentType<T>` is returned by a call to `GetArchetypeChunkSharedComponentType<T>()` within a `ComponentSystem` or `JobComponentSystem`. 
 


### PR DESCRIPTION
Fixed `archetype` vs `chunk` confusion in `Documentation/reference/chunk_iteration.md` (*Accessing SharedComponent (index) data in chunks*).

> However, each `archetype` contains the index of the specific value of the `SharedComponent` which is part of its definition, and indexes into the global list of `SharedComponent` values.

should have read:

>However, each `Chunk` contains the index of the specific value of the `SharedComponent` which is part of its definition, and indexes into the global list of `SharedComponent` values.