### PR TITLE
Fix typos in EntitiesTutorial

### DIFF
--- a/EntitiesSamples/EntitiesTutorial/README.md
+++ b/EntitiesSamples/EntitiesTutorial/README.md
@@ -1134,7 +1134,7 @@ With the three primitives selected, use the "Add Component" button in the inspec
                 UnityEngine.Debug.DrawLine(a * radius, b * radius);
             }
 
-            m_TurretActiveFromEntity.Update(ref state);
+            m_ShootingLookup.Update(ref state);
             var safeZoneJob = new SafeZoneJob
             {
                 ShootingLookup = m_ShootingLookup,

--- a/EntitiesSamples/EntitiesTutorial/README.md
+++ b/EntitiesSamples/EntitiesTutorial/README.md
@@ -527,7 +527,7 @@ When working on larger projects which are split over multiple assemblies, explic
         {
             // ComponentLookup structures have to be initialized once.
             // The parameter specifies if the lookups will be read only or if they should allow writes.
-            m_LocalToWorldTransformFromEntity = state.GetComponentLookup<WorldTransform>(true);
+            m_WorldTransformLookup = state.GetComponentLookup<WorldTransform>(true);
         }
 
         [BurstCompile]
@@ -562,7 +562,7 @@ When working on larger projects which are split over multiple assemblies, explic
     [BurstCompile]
     partial struct TurretShoot : IJobEntity
     {
-        [ReadOnly] public ComponentLookup<LocalToWorldTransform> WorldTransformLookup;
+        [ReadOnly] public ComponentLookup<WorldTransform> WorldTransformLookup;
         public EntityCommandBuffer ECB;
 
         // Note that the TurretAspects parameter is "in", which declares it as read only.

--- a/EntitiesSamples/EntitiesTutorial/README.md
+++ b/EntitiesSamples/EntitiesTutorial/README.md
@@ -1208,6 +1208,7 @@ With the three primitives selected, use the "Add Component" button in the inspec
 1. Create a new C# source file named "CameraSystem.cs" in the folder "Scripts/Systems", put the following contents in there:
 
     ```c#
+    using Unity.Burst;
     using Unity.Collections;
     using Unity.Entities;
     using Unity.Mathematics;
@@ -1246,7 +1247,7 @@ With the three primitives selected, use the "Add Component" button in the inspec
             }
 
             var cameraTransform = CameraSingleton.Instance.transform;
-            var tankTransform = GetComponent<LocalToWorld>(Target);
+            var tankTransform = SystemAPI.GetComponent<LocalToWorld>(Target);
             cameraTransform.position = tankTransform.Position - 10.0f * tankTransform.Forward + new float3(0.0f, 5.0f, 0.0f);
             cameraTransform.LookAt(tankTransform.Position, new float3(0.0f, 1.0f, 0.0f));
         }


### PR DESCRIPTION
Some parts of the code have not been updated after the rename from LocalToWorldTransform to WorldTransform, resulting in compile errors when following the tutorial.