### PR TITLE
Fixed missing flag in HelloCube

### DIFF
--- a/EntitiesSamples/Assets/HelloCube/Common/RotationSpeedAuthoring.cs
+++ b/EntitiesSamples/Assets/HelloCube/Common/RotationSpeedAuthoring.cs
@@ -16,7 +16,7 @@ namespace HelloCube
             public override void Bake(RotationSpeedAuthoring authoring)
             {
                 // The entity will be moved
-                var entity = GetEntity(TransformUsageFlags.Dynamic);
+                var entity = GetEntity(TransformUsageFlags.Dynamic | TransformUsageFlags.NonUniformScale);
                 AddComponent(entity, new RotationSpeed
                 {
                     RadiansPerSecond = math.radians(authoring.DegreesPerSecond)


### PR DESCRIPTION
Fixed "NonUniformScale" flag missing from GetEntity call in RotationSpeedAuthoring for the HelloCube tutorial.

The example runs without it due to the cube in the example scene being non-uniform and therefore gaining PostTransformMatrix, but will cause hard-to-debug issues for anyone recreating the code in the tutorial.