### PR TITLE
Fix Boids MergeCell ExecuteNext bug

### DIFF
--- a/EntitiesSamples/Assets/Boids/Scripts/BoidSystem.cs
+++ b/EntitiesSamples/Assets/Boids/Scripts/BoidSystem.cs
@@ -238,8 +238,8 @@ namespace Boids
             public void ExecuteNext(int cellIndex, int index)
             {
                 cellCount[cellIndex]      += 1;
-                cellAlignment[cellIndex]  += cellAlignment[cellIndex];
-                cellSeparation[cellIndex] += cellSeparation[cellIndex];
+                cellAlignment[cellIndex]  += cellAlignment[index];
+                cellSeparation[cellIndex] += cellSeparation[index];
                 cellIndices[index]        = cellIndex;
             }
         }


### PR DESCRIPTION
I believe there is a typo when upgrade to ecs 1.0, we should add up add entity's forward and position, not the cellindex's. 

<img width="1312" alt="image" src="https://github.com/Unity-Technologies/EntityComponentSystemSamples/assets/1621110/6f847ad0-51aa-4562-970f-db35c85b07da">
