### PR TITLE
Fix TargetingSystem.cs randomly skipping targets

### DIFF
--- a/EntitiesSamples/Assets/Miscellaneous/ClosestTarget/TargetingSystem.cs
+++ b/EntitiesSamples/Assets/Miscellaneous/ClosestTarget/TargetingSystem.cs
@@ -138,7 +138,7 @@ namespace Miscellaneous.ClosestTarget
                 }
 
                 Scratch.Neighbours.Clear();
-                Tree.GetEntriesInRangeWithHeap(unfilteredChunkIndex, transforms[i].Position, float.MaxValue,
+                Tree.GetEntriesInRangeWithHeap(-1, transforms[i].Position, float.MaxValue,
                     ref Scratch.Neighbours);
                 var nearest = Scratch.Neighbours.Peek().index;
                 targets[i] = new Target { Value = TargetEntities[nearest] };


### PR DESCRIPTION
The GetEntriesInRangeWithHeap method is called with unfilteredChunkIndex as the first parameter. This parameter is intended to be an entity index within kdQuery, to ensure the algorithm does not find the entity that is performing the search. However, in this sample, the seeker entities are not included in kdQuery, so there is no need to skip any entity. Passing unfilteredChunkIndex seems arbitrary here, and we could instead pass -1 as a quick fix for the sample:

Tree.GetEntriesInRangeWithHeap(-1, transforms[i].Position, float.MaxValue, ref Scratch.Neighbours);

Related Issue: #275 